### PR TITLE
Invalid hyperlinks for Home and API Documentation

### DIFF
--- a/page/learn.html
+++ b/page/learn.html
@@ -28,13 +28,13 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="logo" href="index.html"><img src="img/logo.png" width="230" alt="Logo"></a>
+				<a class="logo" href="/index.html"><img src="img/logo.png" width="230" alt="Logo"></a>
 			</div>
 
 			<!--Desktop-->
 			<div class="navbar-collapse collapse">
 				<ul class="nav navbar-nav navbar-right">
-					<li><a href="index.html">Home</a></li>
+					<li><a href="/index.html">Home</a></li>
 					<li><a href="learn.html">Learn</a></li>
 					<li><a href="docs">API Documentation</a></li>
 					<li><a href="download.html">Download</a></li>


### PR DESCRIPTION
In the navbar:
1. The homepage links refer to address '[index.](https://www.nunustudio.org/index.html)html' which redirects them to [index.html](https://www.nunustudio.org/page/index.html) in the 'Page' folder. Since no such page exists, Error 404 is thrown. 
2. Similar issue occurs for the 'API Documentation' tab, they are referenced to '[docs](https://www.nunustudio.org/page/docs)', which does not exist in the 'Page' folder.

FIXES:
Renamed the links for homepage to '/index.html' and for the API Documentation as '/docs'.

Thanks!