### PR TITLE
DOC: "sidebar apidocs" to "sidebar", to read it :)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,235 +1,213 @@
 # Changelog
- - All notable changes to this project will be documented in this file, this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
+- All notable changes to this project will be documented in this file, this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### V0.9.7
 
 - Published the project to NPM.
 
-
-
 ### V0.9.6
 
- - Fixed canvas background.
- - Physics object positioning mode.
- - Terrain and shaders tutorials.
- - CSS 3D renderer support.
-   - Perspective transformed HTML containers.
-   - Billboarded HTML containers.
- - Added bitmap text with support for SDF and MSDF text rendering.
- - Added canvas based text with support for CSS styling.
- - Support for extruded or planar Text Mesh.
- - Fixed bug with tree overlapping other tabs.
- - Select multiple tree objects using SHIFT.
- - Export draco compressed geometries.
- - Scene editor toolbar is now attached to the scene editor tab. 
- - Fixed postprocessing pipeline bugs.
- - Adaptive luminance pass.
- - Improve search text box.
- - Fixed scene disposing the first scene loaded before running.
- - Added support for capsule geometry (library)
-
-
+- Fixed canvas background.
+- Physics object positioning mode.
+- Terrain and shaders tutorials.
+- CSS 3D renderer support.
+  - Perspective transformed HTML containers.
+  - Billboarded HTML containers.
+- Added bitmap text with support for SDF and MSDF text rendering.
+- Added canvas based text with support for CSS styling.
+- Support for extruded or planar Text Mesh.
+- Fixed bug with tree overlapping other tabs.
+- Select multiple tree objects using SHIFT.
+- Export draco compressed geometries.
+- Scene editor toolbar is now attached to the scene editor tab. 
+- Fixed postprocessing pipeline bugs.
+- Adaptive luminance pass.
+- Improve search text box.
+- Fixed scene disposing the first scene loaded before running.
+- Added support for capsule geometry (library)
 
 ### V0.9.5
 
- - Split able tabs in the UI
- - Improved form GUI
- - Support for mesh-cap materials
- - Loading data screen
- - Torus knot and ring geometries
- - Post-processing refactored
- - Resource management refactored
- - Remove resources using the keyboard
- - Refactored forms UI
- - Fixed problems with convex hull generation
- - Search bard for objects and resource
- - Automatically focus objects on selection
- - Using NWJS-builder now
- - Fixed shader editor layout
- - Support for Tizen key codes (TizenKeyboard)
- - Video Stream object
- - Mouse back and forward buttons support (Chrome and desktop only).
-
-
+- Split able tabs in the UI
+- Improved form GUI
+- Support for mesh-cap materials
+- Loading data screen
+- Torus knot and ring geometries
+- Post-processing refactored
+- Resource management refactored
+- Remove resources using the keyboard
+- Refactored forms UI
+- Fixed problems with convex hull generation
+- Search bard for objects and resource
+- Automatically focus objects on selection
+- Using NWJS-builder now
+- Fixed shader editor layout
+- Support for Tizen key codes (TizenKeyboard)
+- Video Stream object
+- Mouse back and forward buttons support (Chrome and desktop only).
 
 ### V0.9.4
- - Multi object edit (position, rotation and scale)
- - Support for SVG file loading
- - Improved camera controls
- - New UI elements (Slider, Checkbox)
- - Dodecahedron geometry
- - Resources are now selectable
- - Resource preview on inspector
- - New general settings tab
- - Experimental android export support
 
-
+- Multi object edit (position, rotation and scale)
+- Support for SVG file loading
+- Improved camera controls
+- New UI elements (Slider, Checkbox)
+- Dodecahedron geometry
+- Resources are now selectable
+- Resource preview on inspector
+- New general settings tab
+- Experimental android export support
 
 ### V0.9.3
- - Shadow material
- - Support for .blend files (@Galactrax)
- - Fixed support for spine animations
- - Editor infinite grid
- - Improved history system in the editor
- - Support for mesh modifiers
- - Support for GPU compressed textures
- - Improved texture preview
- - Image and Video can be managed as resources
- - Animation timeline editor
- - Support for external libs in scripts
- - Support for text and code resources
- - Fixed particle scaling issues
- - File export API
 
-
+- Shadow material
+- Support for .blend files (@Galactrax)
+- Fixed support for spine animations
+- Editor infinite grid
+- Improved history system in the editor
+- Support for mesh modifiers
+- Support for GPU compressed textures
+- Improved texture preview
+- Image and Video can be managed as resources
+- Animation timeline editor
+- Support for external libs in scripts
+- Support for text and code resources
+- Fixed particle scaling issues
+- File export API
 
 ### V0.9.2
- - Support for multi selection
- - Geometry binary operations (CSG)
-    - Subtract
-    - Intersect
-    - Union
- - Immediate mode
- - Postprocessing
-    - Postprocessing editor
- - Resize is now a part of Object3D
- - Improvements to nsp files
-    - Moved from base64 to raw binary data.
- - Cube camera preview
- - Fixed dropdown menus getting out of screen
 
-
+- Support for multi selection
+- Geometry binary operations (CSG)
+  - Subtract
+  - Intersect
+  - Union
+- Immediate mode
+- Postprocessing
+  - Postprocessing editor
+- Resize is now a part of Object3D
+- Improvements to nsp files
+  - Moved from base64 to raw binary data.
+- Cube camera preview
+- Fixed dropdown menus getting out of screen
 
 ### V0.9.1
- - Internal debug console
-    - Preview materials and textures in console
-    - Visualize math structures
- - Desktop auto update mechanism (auto download build from git hub master branch)
- - Load 3D file drag and drop with texture support
- - Skeleton serialization (@takahirox)
- - ES6 lint support
- - Support for line and points material
- - Improvements in material editor
 
-
+- Internal debug console
+  - Preview materials and textures in console
+  - Visualize math structures
+- Desktop auto update mechanism (auto download build from git hub master branch)
+- Load 3D file drag and drop with texture support
+- Skeleton serialization (@takahirox)
+- ES6 lint support
+- Support for line and points material
+- Improvements in material editor
 
 ### V0.9.0
- - Division property for HTML elements
- - Camera preview positioning
- - Cube maps from equirectangular projection
- - Binary project files (.nsp)
 
-
+- Division property for HTML elements
+- Camera preview positioning
+- Cube maps from equirectangular projection
+- Binary project files (.nsp)
 
 ### V0.8.9.26
- - Improved audio implementation
- - Control sky colors on UI
- - Keyboard navigation in orbit mode
- - Export projects from web version
- - Calculate texture offset and repeat to fit aspect ratio in square
- - Code autocomplete from documentation
- - Keep file name on web version
- - Force WebGL context loss when tabs closed
 
-
+- Improved audio implementation
+- Control sky colors on UI
+- Keyboard navigation in orbit mode
+- Export projects from web version
+- Calculate texture offset and repeat to fit aspect ratio in square
+- Code autocomplete from documentation
+- Keep file name on web version
+- Force WebGL context loss when tabs closed
 
 ### V0.8.9.25
- - Added Cube Camera
- - Added Sprite Sheet texture animation support
- - Gamepad support
- - Improved UI elements
 
-
+- Added Cube Camera
+- Added Sprite Sheet texture animation support
+- Gamepad support
+- Improved UI elements
 
 ### V0.8.9.24
- - Added snap to grid
- - First version of NodeJS build system (@GGAlanSmithee)
- - Open ISP as url argument on web version
- - Support for orbit navigation
 
-
+- Added snap to grid
+- First version of NodeJS build system (@GGAlanSmithee)
+- Open ISP as url argument on web version
+- Support for orbit navigation
 
 ### V0.8.9.23
- - Added support for STL files
- - Fixed locked keys in Keyboard after alerts, prompts, etc
- - Added support for nested menu in Context Menus
- - Support for 3DS files
- - Circle Geometry
 
-
+- Added support for STL files
+- Fixed locked keys in Keyboard after alerts, prompts, etc
+- Added support for nested menu in Context Menus
+- Support for 3DS files
+- Circle Geometry
 
 ### V0.8.9.22
- - Removed editor state, tabs are self updated
 
-
+- Removed editor state, tabs are self updated
 
 ### V0.8.9.21
- - Editor standalone version (@Seagat2011)
- - Support for File API loading
- - Added reverse glyphs option to Font asset
- - Improved font preview
- - Added support for Textures as scene background
- - Drag and drop Cube Textures
- - Drag and drop tabs in editor
 
-
+- Editor standalone version (@Seagat2011)
+- Support for File API loading
+- Added reverse glyphs option to Font asset
+- Improved font preview
+- Added support for Textures as scene background
+- Drag and drop Cube Textures
+- Drag and drop tabs in editor
 
 ### V0.8.9.20
- - Cube texture support
- - Improved material serialization
- - Sort objects in the explorer
 
-
+- Cube texture support
+- Improved material serialization
+- Sort objects in the explorer
 
 ### V0.8.9.19
- - Renamed variables variable_name to variableName
- - Added Texture Editor
- - Documentation page
 
-
+- Renamed variables variable_name to variableName
+- Added Texture Editor
+- Documentation page
 
 ### V0.8.9.18
- - Added geometry properties to geometry panels
- - Camera draw order
- - Fixed OBJ and MTL loading
- - Default app export template loading screen
- - Audio preview
 
-
+- Added geometry properties to geometry panels
+- Camera draw order
+- Fixed OBJ and MTL loading
+- Default app export template loading screen
+- Audio preview
 
 ### V0.8.9.17
- - Particle editor position, velocity and acceleration delta now shows in different a row
- - Fixed program resources dispose
- - Added support for mouse lock on runtime
- - Added RectArea light support
- - Added MTL loading support
- - Added program, scene and self variables to scripts (can be used without this reference)
- - Generic multi file format 3D model loading
 
-
+- Particle editor position, velocity and acceleration delta now shows in different a row
+- Fixed program resources dispose
+- Added support for mouse lock on runtime
+- Added RectArea light support
+- Added MTL loading support
+- Added program, scene and self variables to scripts (can be used without this reference)
+- Generic multi file format 3D model loading
 
 ### V0.8.9.16
- - Fixed file path changing after project export
- - Program rendering settings (Antialiasing, Shadows)
- - Text3D now supports line break with '\n'
- - Text3D panel can be used to edit multiline text
- - Program stores pointer to nunu app (program.app)
- - Added program.sendDataApp and app.setOnDataReceived for app/page communication
- - Renamed NunuRuntime to NunuApp (Makes more sense)
- - Fixed copy/paste inside object panels
 
-
+- Fixed file path changing after project export
+- Program rendering settings (Antialiasing, Shadows)
+- Text3D now supports line break with '\n'
+- Text3D panel can be used to edit multiline text
+- Program stores pointer to nunu app (program.app)
+- Added program.sendDataApp and app.setOnDataReceived for app/page communication
+- Renamed NunuRuntime to NunuApp (Makes more sense)
+- Fixed copy/paste inside object panels
 
 ### V0.8.9.15
- - Added font preview in asset explorer
- - Fixed material preview projection
- - Projects can be loaded when dragged anywhere
- - Videos and images can now be exported to files
-	 - Left click on texture inside the asset explorer and select Export Image/Video
- - Added support for Positional Audio
-	 - Audio relative to origin
- - Fonts can now be dragged directly to an object
- - Fixed script onResize method
- - Projects can now be run by pressing F5
+
+- Added font preview in asset explorer
+- Fixed material preview projection
+- Projects can be loaded when dragged anywhere
+- Videos and images can now be exported to files
+  - Left click on texture inside the asset explorer and select Export Image/Video
+- Added support for Positional Audio
+  - Audio relative to origin
+- Fonts can now be dragged directly to an object
+- Fixed script onResize method
+- Projects can now be run by pressing F5

--- a/README.md
+++ b/README.md
@@ -2,28 +2,30 @@
 
 [![GitHub version](https://badge.fury.io/gh/tentone%2FnunuStudio.svg)](https://badge.fury.io/gh/tentone%2FnunuStudio)[![npm version](https://badge.fury.io/js/nunu-studio.svg)](https://badge.fury.io/js/nunu-studio)[![GitHub issues](https://img.shields.io/github/issues/tentone/nunuStudio.svg)](https://github.com/tentone/nunuStudio/issues) [![GitHub stars](https://img.shields.io/github/stars/tentone/nunuStudio.svg)](https://github.com/tentone/nunuStudio/stargazers)
 
- - nunuStudio is an open source 3D VR game engine for the web it allows designers and web developers to easily develop 3D experiences that can run directly in a web page or be exported as Desktop applications.
- - It has a fully featured visual editor, supports a wide range of file formats, the tools are open source and completely free to use for both personal and commercial usage, it is powered by open web APIs like WebGL, WebXR and Web Audio.
- - Visual scene editor, code editor, visual tools to edit textures, materials, particle emitters and a powerful scripting API that allows the creation of complex applications.
- - The project  build on top of open source libraries with good community support like [nwjs.io](https://nwjs.io), [three.js](https://github.com/mrdoob/three.js), [cannon.js](https://schteppe.github.io/cannon.js), [opentype](https://opentype.js.org), [jscolor.com](http://jscolor.com), [codemirror.net](https://codemirror.net), [leapjs](https://github.com/leapmotion/leapjs), [jshint.com](https://jshint.com), [yuidoc](https://yui.github.io/yuidoc)
+- nunuStudio is an open source 3D VR game engine for the web it allows designers and web developers to easily develop 3D experiences that can run directly in a web page or be exported as Desktop applications.
 
- - Fully featured [web version](https://www.nunustudio.org/build/editor/index.html) of the editor is available on the project page.
- - The web version is tested with [Firefox](https://www.mozilla.org/en-US/firefox/new/), [Chrome](https://www.google.com/chrome/) and [Microsoft Edge](https://www.microsoft.com/en-us/edge), mobile browsers are supported as well.
+- It has a fully featured visual editor, supports a wide range of file formats, the tools are open source and completely free to use for both personal and commercial usage, it is powered by open web APIs like WebGL, WebXR and Web Audio.
+
+- Visual scene editor, code editor, visual tools to edit textures, materials, particle emitters and a powerful scripting API that allows the creation of complex applications.
+
+- The project  build on top of open source libraries with good community support like [nwjs.io](https://nwjs.io), [three.js](https://github.com/mrdoob/three.js), [cannon.js](https://schteppe.github.io/cannon.js), [opentype](https://opentype.js.org), [jscolor.com](http://jscolor.com), [codemirror.net](https://codemirror.net), [leapjs](https://github.com/leapmotion/leapjs), [jshint.com](https://jshint.com), [yuidoc](https://yui.github.io/yuidoc)
+
+- Fully featured [web version](https://www.nunustudio.org/build/editor/index.html) of the editor is available on the project page.
+
+- The web version is tested with [Firefox](https://www.mozilla.org/en-US/firefox/new/), [Chrome](https://www.google.com/chrome/) and [Microsoft Edge](https://www.microsoft.com/en-us/edge), mobile browsers are supported as well.
 
 <img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/web.png">
 
 ### Getting Started
- - [API Documentation](https://nunustudio.org/docs) with full details about the inner working of every module are available. These can also be generated from the project source code by running `npm run docs`.
- - Basic tutorials are available on the [project page](https://www.nunustudio.org/page/learn.html). The basic tutorials explain step-by-step how to use the editor.
 
-
+- [API Documentation](https://nunustudio.org/docs) with full details about the inner working of every module are available. These can also be generated from the project source code by running `npm run docs`.
+- Basic tutorials are available on the [project page](https://www.nunustudio.org/page/learn.html). The basic tutorials explain step-by-step how to use the editor.
 
 ### Screenshots
+
 <img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/2.png"><img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/3.png">
 <img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/4.png"><img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/1.png">
 <img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/5.png"><img src="https://raw.githubusercontent.com/tentone/nunuStudio/master/source/page/src/assets/github/6.png">
-
-
 
 ### Features
 
@@ -39,9 +41,8 @@
 - Physics powered by [cannon.js](https://schteppe.github.io/cannon.js/)
 - Compatible with [WebXR](https://www.w3.org/TR/webxr/) for Virtual Reality and Augmented Reality
 
-
-
 ### Building
+
 - The project uses a custom solution for code bundling
   - The building system generates minified builds for the runtime and for the editor
   - JavaScript is optimized and minified using [Google closure](https://developers.google.com/closure/library)
@@ -50,27 +51,23 @@
 - Install dependencies from npm by running `npm install`
 - Build  editor, runtime and documentation, run `npm run build`
 
-
-
 #### Embedding Application
+
 - Application developed with can be embedded into already existing web pages, and are compatible with frameworks like [Angular](https://angular.io/) or [React](https://reactjs.org/).
 - To embed applications in HTML pages the following code can be used, the application is bootstrapped using the `loadApp(file, id)` method.
 
 ```html
 <html>
-	<head>
-		<script src="nunu.min.js"></script>
-	</head>
-	<body onload="NunuApp.loadApp('pong.nsp', 'canvas')">
-		<canvas width="800" height="480" id="canvas"></canvas>
-	</body>
+    <head>
+        <script src="nunu.min.js"></script>
+    </head>
+    <body onload="NunuApp.loadApp('pong.nsp', 'canvas')">
+        <canvas width="800" height="480" id="canvas"></canvas>
+    </body>
 </html>
 ```
-
-
 
 ### License
 
 - The project is distributed under a MIT license that allow for commercial usage of the platform without any cost.
 - The license is available on the project GitHub page
-

--- a/docs/docs/classes/ARHandler.html
+++ b/docs/docs/classes/ARHandler.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/AfterimagePass.html
+++ b/docs/docs/classes/AfterimagePass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/AmbientLight.html
+++ b/docs/docs/classes/AmbientLight.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/AnimationMixer.html
+++ b/docs/docs/classes/AnimationMixer.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/AnimationTimer.html
+++ b/docs/docs/classes/AnimationTimer.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/App.html
+++ b/docs/docs/classes/App.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ArraybufferUtils.html
+++ b/docs/docs/classes/ArraybufferUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Audio.html
+++ b/docs/docs/classes/Audio.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/AudioEmitter.html
+++ b/docs/docs/classes/AudioEmitter.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/AudioLoader.html
+++ b/docs/docs/classes/AudioLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Base64Utils.html
+++ b/docs/docs/classes/Base64Utils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/BaseNode.html
+++ b/docs/docs/classes/BaseNode.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/BillboardGroup.html
+++ b/docs/docs/classes/BillboardGroup.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/BloomPass.html
+++ b/docs/docs/classes/BloomPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/BokehPass.html
+++ b/docs/docs/classes/BokehPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/BufferUtils.html
+++ b/docs/docs/classes/BufferUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ByteArrayUtils.html
+++ b/docs/docs/classes/ByteArrayUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CSS3DObject.html
+++ b/docs/docs/classes/CSS3DObject.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CSS3DRenderer.html
+++ b/docs/docs/classes/CSS3DRenderer.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CSS3DSprite.html
+++ b/docs/docs/classes/CSS3DSprite.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CanvasSprite.html
+++ b/docs/docs/classes/CanvasSprite.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CanvasTexture.html
+++ b/docs/docs/classes/CanvasTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CapsuleBufferGeometry.html
+++ b/docs/docs/classes/CapsuleBufferGeometry.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ColorifyPass.html
+++ b/docs/docs/classes/ColorifyPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CompressedTexture.html
+++ b/docs/docs/classes/CompressedTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CopyPass.html
+++ b/docs/docs/classes/CopyPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CubeCamera.html
+++ b/docs/docs/classes/CubeCamera.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/CubeTexture.html
+++ b/docs/docs/classes/CubeTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/DataTexture.html
+++ b/docs/docs/classes/DataTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/DirectionalLight.html
+++ b/docs/docs/classes/DirectionalLight.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/DirectionalLightCSM.html
+++ b/docs/docs/classes/DirectionalLightCSM.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/DotScreenPass.html
+++ b/docs/docs/classes/DotScreenPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/EffectComposer.html
+++ b/docs/docs/classes/EffectComposer.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/EventManager.html
+++ b/docs/docs/classes/EventManager.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/FXAAPass.html
+++ b/docs/docs/classes/FXAAPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/FileSystem.html
+++ b/docs/docs/classes/FileSystem.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/FilmPass.html
+++ b/docs/docs/classes/FilmPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/FirstPersonControls.html
+++ b/docs/docs/classes/FirstPersonControls.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Fog.html
+++ b/docs/docs/classes/Fog.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Font.html
+++ b/docs/docs/classes/Font.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/FontLoader.html
+++ b/docs/docs/classes/FontLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Gamepad.html
+++ b/docs/docs/classes/Gamepad.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/GeometryLoader.html
+++ b/docs/docs/classes/GeometryLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Group.html
+++ b/docs/docs/classes/Group.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Gyroscope.html
+++ b/docs/docs/classes/Gyroscope.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/HTMLView.html
+++ b/docs/docs/classes/HTMLView.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/HemisphereLight.html
+++ b/docs/docs/classes/HemisphereLight.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/HueSaturationPass.html
+++ b/docs/docs/classes/HueSaturationPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Image.html
+++ b/docs/docs/classes/Image.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ImageLoader.html
+++ b/docs/docs/classes/ImageLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/InstancedMesh.html
+++ b/docs/docs/classes/InstancedMesh.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Key.html
+++ b/docs/docs/classes/Key.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Keyboard.html
+++ b/docs/docs/classes/Keyboard.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/LegacyGeometryLoader.html
+++ b/docs/docs/classes/LegacyGeometryLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/LensFlare.html
+++ b/docs/docs/classes/LensFlare.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/LightProbe.html
+++ b/docs/docs/classes/LightProbe.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/LocalStorage.html
+++ b/docs/docs/classes/LocalStorage.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Material.html
+++ b/docs/docs/classes/Material.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/MaterialLoader.html
+++ b/docs/docs/classes/MaterialLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/MathUtils.html
+++ b/docs/docs/classes/MathUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Mesh.html
+++ b/docs/docs/classes/Mesh.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Model.html
+++ b/docs/docs/classes/Model.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Mouse.html
+++ b/docs/docs/classes/Mouse.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/NodeScript.html
+++ b/docs/docs/classes/NodeScript.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Nunu.html
+++ b/docs/docs/classes/Nunu.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Object3D.html
+++ b/docs/docs/classes/Object3D.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ObjectLoader.html
+++ b/docs/docs/classes/ObjectLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ObjectUtils.html
+++ b/docs/docs/classes/ObjectUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/OperationNode.html
+++ b/docs/docs/classes/OperationNode.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/OrbitControls.html
+++ b/docs/docs/classes/OrbitControls.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/OrthographicCamera.html
+++ b/docs/docs/classes/OrthographicCamera.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ParametricBufferGeometry.html
+++ b/docs/docs/classes/ParametricBufferGeometry.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ParticleDistributions.html
+++ b/docs/docs/classes/ParticleDistributions.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ParticleEmitter.html
+++ b/docs/docs/classes/ParticleEmitter.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ParticleEmitterControl.html
+++ b/docs/docs/classes/ParticleEmitterControl.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ParticleEmitterControlOptions.html
+++ b/docs/docs/classes/ParticleEmitterControlOptions.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ParticleGroup.html
+++ b/docs/docs/classes/ParticleGroup.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Pass.html
+++ b/docs/docs/classes/Pass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/PerspectiveCamera.html
+++ b/docs/docs/classes/PerspectiveCamera.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/PhysicsGenerator.html
+++ b/docs/docs/classes/PhysicsGenerator.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/PhysicsObject.html
+++ b/docs/docs/classes/PhysicsObject.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/PointLight.html
+++ b/docs/docs/classes/PointLight.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/PositionalAudio.html
+++ b/docs/docs/classes/PositionalAudio.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Program.html
+++ b/docs/docs/classes/Program.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/PythonScript.html
+++ b/docs/docs/classes/PythonScript.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/RectAreaLight.html
+++ b/docs/docs/classes/RectAreaLight.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/RenderPass.html
+++ b/docs/docs/classes/RenderPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/RendererConfiguration.html
+++ b/docs/docs/classes/RendererConfiguration.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/RendererState.html
+++ b/docs/docs/classes/RendererState.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Resource.html
+++ b/docs/docs/classes/Resource.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ResourceManager.html
+++ b/docs/docs/classes/ResourceManager.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/RoundedBoxBufferGeometry.html
+++ b/docs/docs/classes/RoundedBoxBufferGeometry.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SSAONOHPass.html
+++ b/docs/docs/classes/SSAONOHPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SSAOPass.html
+++ b/docs/docs/classes/SSAOPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SSAOShader.html
+++ b/docs/docs/classes/SSAOShader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Scene.html
+++ b/docs/docs/classes/Scene.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Script.html
+++ b/docs/docs/classes/Script.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ShaderAttribute.html
+++ b/docs/docs/classes/ShaderAttribute.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ShaderPass.html
+++ b/docs/docs/classes/ShaderPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/ShaderUtils.html
+++ b/docs/docs/classes/ShaderUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SimplexNoise.html
+++ b/docs/docs/classes/SimplexNoise.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Skeleton.html
+++ b/docs/docs/classes/Skeleton.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SkinnedMesh.html
+++ b/docs/docs/classes/SkinnedMesh.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Sky.html
+++ b/docs/docs/classes/Sky.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SobelPass.html
+++ b/docs/docs/classes/SobelPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SpineAnimation.html
+++ b/docs/docs/classes/SpineAnimation.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SpineTexture.html
+++ b/docs/docs/classes/SpineTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SpotLight.html
+++ b/docs/docs/classes/SpotLight.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Sprite.html
+++ b/docs/docs/classes/Sprite.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/SpriteSheetTexture.html
+++ b/docs/docs/classes/SpriteSheetTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TargetConfig.html
+++ b/docs/docs/classes/TargetConfig.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TechnicolorPass.html
+++ b/docs/docs/classes/TechnicolorPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TerrainBufferGeometry.html
+++ b/docs/docs/classes/TerrainBufferGeometry.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TextBitmap.html
+++ b/docs/docs/classes/TextBitmap.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TextFile.html
+++ b/docs/docs/classes/TextFile.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TextMesh.html
+++ b/docs/docs/classes/TextMesh.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TextSprite.html
+++ b/docs/docs/classes/TextSprite.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Texture.html
+++ b/docs/docs/classes/Texture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TextureLoader.html
+++ b/docs/docs/classes/TextureLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Timer.html
+++ b/docs/docs/classes/Timer.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TizenKeyboard.html
+++ b/docs/docs/classes/TizenKeyboard.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Tree.html
+++ b/docs/docs/classes/Tree.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TreeUtils.html
+++ b/docs/docs/classes/TreeUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TwistModifier.html
+++ b/docs/docs/classes/TwistModifier.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/TypedArrayHelper.html
+++ b/docs/docs/classes/TypedArrayHelper.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/UnitConverter.html
+++ b/docs/docs/classes/UnitConverter.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/UnrealBloomPass.html
+++ b/docs/docs/classes/UnrealBloomPass.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/VRHandler.html
+++ b/docs/docs/classes/VRHandler.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Video.html
+++ b/docs/docs/classes/Video.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/VideoLoader.html
+++ b/docs/docs/classes/VideoLoader.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/VideoStream.html
+++ b/docs/docs/classes/VideoStream.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/VideoTexture.html
+++ b/docs/docs/classes/VideoTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/Viewport.html
+++ b/docs/docs/classes/Viewport.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/WebcamTexture.html
+++ b/docs/docs/classes/WebcamTexture.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/WorkerPool.html
+++ b/docs/docs/classes/WorkerPool.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/WorkerTask.html
+++ b/docs/docs/classes/WorkerTask.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/classes/{Object} ParticleGroupOptions.html
+++ b/docs/docs/classes/{Object} ParticleGroupOptions.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Animation.html
+++ b/docs/docs/modules/Animation.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Animations.html
+++ b/docs/docs/modules/Animations.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Audio.html
+++ b/docs/docs/modules/Audio.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/BinaryUtils.html
+++ b/docs/docs/modules/BinaryUtils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Cameras.html
+++ b/docs/docs/modules/Cameras.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Controls.html
+++ b/docs/docs/modules/Controls.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Core.html
+++ b/docs/docs/modules/Core.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Files.html
+++ b/docs/docs/modules/Files.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Input.html
+++ b/docs/docs/modules/Input.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Lights.html
+++ b/docs/docs/modules/Lights.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Loaders.html
+++ b/docs/docs/modules/Loaders.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Meshes.html
+++ b/docs/docs/modules/Meshes.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Misc.html
+++ b/docs/docs/modules/Misc.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Particles.html
+++ b/docs/docs/modules/Particles.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Physics.html
+++ b/docs/docs/modules/Physics.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Postprocessing.html
+++ b/docs/docs/modules/Postprocessing.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Resources.html
+++ b/docs/docs/modules/Resources.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Runtime.html
+++ b/docs/docs/modules/Runtime.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Script.html
+++ b/docs/docs/modules/Script.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Sprite.html
+++ b/docs/docs/modules/Sprite.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/THREE.html
+++ b/docs/docs/modules/THREE.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Textures.html
+++ b/docs/docs/modules/Textures.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/docs/docs/modules/Utils.html
+++ b/docs/docs/modules/Utils.html
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					<div id="api-list">
 						<h2 class="off-left">APIs</h2>
 						<div id="api-tabview" class="tabview">

--- a/source/theme-docs/layouts/main.handlebars
+++ b/source/theme-docs/layouts/main.handlebars
@@ -25,7 +25,7 @@
 		</div>
 		<div id="bd" class="yui3-g">
 			<div class="yui3-u-1-4">
-				<div id="docs-sidebar" class="sidebar apidocs">
+				<div id="docs-sidebar" class="sidebar">
 					{{>sidebar}}
 				</div>
 			</div>


### PR DESCRIPTION
My first PR to your repo :)
Hope it helps

## Description
[Docs](https://www.nunustudio.org/docs/) are unreadable because sidebar is not displaying.
Fixes # (https://github.com/tentone/nunuStudio/issues/470)

## Type of change
Simply changed "sidebar apidocs" to "sidebar" over all files. 
Theme and actual doc pages were changed
I didn't re-run `npm run-script docs-jsdoc` nor `npm run-script docs` (was it needed?)

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Opened the docs/index.html and sidebar is visible and working fine.

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
