### PR TITLE
make PWA icons maskable

### DIFF
--- a/docs/editor/manifest.json
+++ b/docs/editor/manifest.json
@@ -6,19 +6,19 @@
         "src": "icons/icon-512.png",
         "type": "image/png",
         "sizes": "512x512",
-        "purpose": "maskable"
+        "purpose": "any maskable"
       },
       {
         "src": "icons/icon-192.ico",
         "type": "image/x-icon",
         "sizes": "192x192",
-        "purpose": "maskable"
+        "purpose": "any maskable"
       },
       {
         "src": "icons/icon-128.ico",
         "type": "image/x-icon",
         "sizes": "128x128",
-        "purpose": "maskable"
+        "purpose": "any maskable"
       }
     ],
     "id": "/",

--- a/docs/editor/manifest.json
+++ b/docs/editor/manifest.json
@@ -6,19 +6,19 @@
         "src": "icons/icon-512.png",
         "type": "image/png",
         "sizes": "512x512",
-        "purpose": "any"
+        "purpose": "maskable"
       },
       {
         "src": "icons/icon-192.ico",
         "type": "image/x-icon",
         "sizes": "192x192",
-        "purpose": "any"
+        "purpose": "maskable"
       },
       {
         "src": "icons/icon-128.ico",
         "type": "image/x-icon",
         "sizes": "128x128",
-        "purpose": "any"
+        "purpose": "maskable"
       }
     ],
     "id": "/",


### PR DESCRIPTION
# Pull Request Template

## Description

changed icon "purpose" to "any maskable" to make the PWA installable while enabling masking of the icon

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
I tested this on replit.com. the link to the preview is [https://nunustudio.glitch128.repl.co/docs/editor/index.html](https://nunustudio.glitch128.repl.co/docs/editor/index.html). The install prompt will appear in the address bar automatically.
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
