### PR TITLE
Add measurement tool for scene editor

### DIFF
--- a/source/core/loaders/ObjectLoader.js
+++ b/source/core/loaders/ObjectLoader.js
@@ -12,6 +12,7 @@ import {InstancedMesh} from "../objects/mesh/InstancedMesh.js";
 import {LensFlare} from "../objects/misc/LensFlare.js";
 import {LightProbe} from "../objects/lights/LightProbe.js";
 import {Mesh} from "../objects/mesh/Mesh.js";
+import {Measurement} from "../objects/misc/Measurement.js";
 import {OrbitControls} from "../objects/controls/OrbitControls.js";
 import {OrthographicCamera} from "../objects/cameras/OrthographicCamera.js";
 import {ParticleEmitter} from "../objects/particle/ParticleEmitter.js";
@@ -882,6 +883,10 @@ ObjectLoader.prototype.parseObject = function(data)
 
 		case "Sprite":
 			object = new Sprite(this.getMaterial(data.material));
+			break;
+
+		case "Measurement":
+			object = Measurement.fromJSON(data);
 			break;
 
 		case "Group":

--- a/source/core/objects/misc/Measurement.js
+++ b/source/core/objects/misc/Measurement.js
@@ -1,0 +1,137 @@
+import {Group as TGroup, BufferGeometry, Float32BufferAttribute, Line, LineBasicMaterial, Vector3} from "three";
+import {TextSprite} from "../text/TextSprite.js";
+
+/**
+ * Measurement object draws a line between two points and displays the distance value.
+ *
+ * @class Measurement
+ * @extends {Group}
+ */
+function Measurement()
+{
+	TGroup.call(this);
+
+	this.name = "measurement";
+	this.type = "Measurement";
+
+	this.start = new Vector3(0, 0, 0);
+	this.end = new Vector3(1, 0, 0);
+	this.precision = 2;
+
+	this._startWorld = new Vector3();
+	this._endWorld = new Vector3();
+	this._midpoint = new Vector3();
+	this._lastDistance = -1;
+
+	var geometry = new BufferGeometry();
+	geometry.setAttribute("position", new Float32BufferAttribute([0, 0, 0, 1, 0, 0], 3));
+	this.line = new Line(geometry, new LineBasicMaterial({color: 0xFFFF00}));
+	this.line.frustumCulled = false;
+	this.add(this.line);
+
+	this.label = new TextSprite();
+	this.label.sizeAttenuation = false;
+	this.label.color = "#FFFF00";
+	this.label.outlineColor = "#000000";
+	this.label.outlineWidth = 2;
+	this.label.material.depthTest = false;
+	this.label.material.depthWrite = false;
+	this.label.material.needsUpdate = true;
+	this.label.scale.setScalar(0.5);
+	this.add(this.label);
+
+	this.updateGeometry();
+}
+
+Measurement.prototype = Object.create(TGroup.prototype);
+Measurement.prototype.constructor = Measurement;
+
+Measurement.prototype.setPoints = function(start, end)
+{
+	this.position.copy(start);
+	this.start.set(0, 0, 0);
+	this.end.copy(end).sub(start);
+	this._lastDistance = -1;
+	this.updateGeometry();
+};
+
+Measurement.prototype.setLocalPoints = function(start, end)
+{
+	this.start.copy(start);
+	this.end.copy(end);
+	this._lastDistance = -1;
+	this.updateGeometry();
+};
+
+Measurement.prototype.updateGeometry = function()
+{
+	var position = this.line.geometry.attributes.position;
+	position.setXYZ(0, this.start.x, this.start.y, this.start.z);
+	position.setXYZ(1, this.end.x, this.end.y, this.end.z);
+	position.needsUpdate = true;
+	this.line.geometry.computeBoundingSphere();
+
+	this._midpoint.copy(this.start).add(this.end).multiplyScalar(0.5);
+	this.label.position.copy(this._midpoint);
+
+	this.updateLabel();
+};
+
+Measurement.prototype.updateLabel = function()
+{
+	this._startWorld.copy(this.start);
+	this.localToWorld(this._startWorld);
+	this._endWorld.copy(this.end);
+	this.localToWorld(this._endWorld);
+
+	var distance = this._startWorld.distanceTo(this._endWorld);
+
+	if (this._lastDistance < 0 || Math.abs(this._lastDistance - distance) > 1e-4)
+	{
+	        this._lastDistance = distance;
+	        this.label.text = distance.toFixed(this.precision);
+	}
+};
+
+Measurement.prototype.updateMatrixWorld = function(force)
+{
+	TGroup.prototype.updateMatrixWorld.call(this, force);
+	this.updateLabel();
+};
+
+Measurement.prototype.toJSON = function(meta)
+{
+	var data = TGroup.prototype.toJSON.call(this, meta);
+
+	data.object.start = this.start.toArray();
+	data.object.end = this.end.toArray();
+	data.object.precision = this.precision;
+	data.object.children = [];
+
+	return data;
+};
+
+Measurement.fromJSON = function(data)
+{
+	var measurement = new Measurement();
+	measurement.precision = data.precision !== undefined ? data.precision : 2;
+
+	var start = new Vector3();
+	var end = new Vector3(1, 0, 0);
+
+	if (data.start !== undefined)
+	{
+	        start.fromArray(data.start);
+	}
+
+	if (data.end !== undefined)
+	{
+	        end.fromArray(data.end);
+	}
+
+	measurement.setLocalPoints(start, end);
+
+	return measurement;
+};
+
+export {Measurement};

--- a/source/editor/gui/tab/scene-editor/toolbar/ToolBar.js
+++ b/source/editor/gui/tab/scene-editor/toolbar/ToolBar.js
@@ -56,6 +56,10 @@ function ToolBar(parent)
 	{
 		self.parent.selectTool(SceneEditor.ROTATE);
 	});
+	this.measure = tool.addToggleOption(Locale.measure + " (CTRL+5)", Global.FILE_PATH + "icons/misc/ruler.png", function()
+	{
+		self.parent.selectTool(SceneEditor.MEASURE);
+	});
 
 	var zoom = this.addGroup();
 	this.zoom = zoom.addOption(Locale.focusObject + " (CTRL+F)", Global.FILE_PATH + "icons/misc/focus.png", function()
@@ -74,6 +78,7 @@ ToolBar.prototype.selectTool = function(tool)
 	this.move.setSelected(tool === SceneEditor.MOVE);
 	this.scale.setSelected(tool === SceneEditor.SCALE);
 	this.rotate.setSelected(tool === SceneEditor.ROTATE);
+	this.measure.setSelected(tool === SceneEditor.MEASURE);
 };
 
 /**

--- a/source/editor/locale/LocaleEN.js
+++ b/source/editor/locale/LocaleEN.js
@@ -501,6 +501,7 @@ var LocaleEN = {
 	toggleSnapToGrid: "Toggle Snap to Grid",
 	scene: "Scene",
 	move: "Move",
+	measure: "Measure",
 	play: "Play",
 	selectObjects: "Select Objects",
 	calculateProbe: "Calculate Light",
@@ -556,6 +557,7 @@ var LocaleEN = {
 	selectObjectEditAnimation: "Select an object to edit animation.",
 	nothingToShow: "Select an object to view its properties.",
 	selectObjectFirst: "Need to select an object first before performing this operation.",
+	selectMeasurementPoints: "Select two points in the scene to create a measurement.",
 
 	// Errors
 	errorExportingProject: "Error exporting project",

--- a/source/editor/utils/ObjectIcons.js
+++ b/source/editor/utils/ObjectIcons.js
@@ -73,6 +73,7 @@ ObjectIcons.icons = new Map([
 	["CubeCamera", ObjectIcons.path + "misc/probe.png"],
 	["Bone", ObjectIcons.path + "misc/bone.png"],
 	["Group", ObjectIcons.path + "misc/container.png"],
+	["Measurement", ObjectIcons.path + "misc/ruler.png"],
 	["BillboardGroup", ObjectIcons.path + "misc/rotate.png"],
 	["LensFlare", ObjectIcons.path + "misc/flare.png"],
 	["OrbitControls", ObjectIcons.path + "misc/orbit.png"],


### PR DESCRIPTION
## Summary
- add a measurement tool workflow to the scene editor, including preview and object creation
- introduce a Measurement core object with line-and-label visualization and JSON serialization support
- expose the tool in the toolbar/localization/icon map and ensure it loads correctly via the object loader

## Testing
- `npm run lint` *(fails: ESLint requires migrating to eslint.config.js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d003457ad083329f217cb2c35104b2