### PR TITLE
Handle geometry parsing failures

### DIFF
--- a/source/core/loaders/GeometryLoader.js
+++ b/source/core/loaders/GeometryLoader.js
@@ -1,4 +1,4 @@
-import {DefaultLoadingManager, FileLoader, ObjectLoader} from "three";
+import {BufferGeometry, DefaultLoadingManager, FileLoader, ObjectLoader} from "three";
 import {TerrainBufferGeometry} from "../geometries/TerrainBufferGeometry.js";
 import {RoundedBoxBufferGeometry} from "../geometries/RoundedBoxBufferGeometry.js";
 import {CapsuleBufferGeometry} from "../geometries/CapsuleBufferGeometry.js";
@@ -99,11 +99,20 @@ GeometryLoader.prototype.parse = function(data)
 
 	else
 	{
-		var geometries = ObjectLoader.prototype.parseGeometries([data], this.shapes);
-		for (var i in geometries)
+		try
 		{
-			geometry = geometries[i];
-			break;
+			var geometries = ObjectLoader.prototype.parseGeometries([data], this.shapes);
+			for (var i in geometries)
+			{
+				geometry = geometries[i];
+				break;
+			}
+		}
+		catch (e)
+		{
+			console.warn("nunuStudio: Failed to parse geometry", data.type, data.uuid, e);
+
+			geometry = new BufferGeometry();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- guard `GeometryLoader` parsing to catch errors thrown by Three.js when shape data is missing
- fall back to an empty `BufferGeometry` and log a warning so TextMesh deserialization no longer crashes

## Testing
- `npm run lint` *(fails: existing indentation violations in source/editor/gui/tab/scene-editor/SceneEditor.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d0502cc0d883329b82febda6c5e1ca